### PR TITLE
Added specific nav history behaviour for search

### DIFF
--- a/app/libs/moxiejs/app/places/templates/item.handlebars
+++ b/app/libs/moxiejs/app/places/templates/item.handlebars
@@ -3,7 +3,7 @@
         {{#if trackingUserPosition}}
             <span class="distance">{{humaniseDistance distance }}</span>
         {{/if}}
-        <a href="{{ reverse 'detail' 'id' id }}">
+        <a class="result-link" id="{{ id }}" href="{{ reverse 'detail' 'id' id }}">
             {{ name }}
         </a>
     </h3>
@@ -20,7 +20,7 @@
         {{#if trackingUserPosition}}
             <span class="distance">{{humaniseDistance distance }}</span>
         {{/if}}
-        <a href="{{ reverse 'detail' 'id' id }}">
+        <a class="result-link" id="{{ id }}" href="{{ reverse 'detail' 'id' id }}">
         {{ type_name }}
         </a>
     </p>

--- a/app/libs/moxiejs/app/places/views/ItemView.js
+++ b/app/libs/moxiejs/app/places/views/ItemView.js
@@ -1,6 +1,7 @@
 define(["backbone", "underscore", "hbs!places/templates/item"], function(Backbone, _, itemTemplate){
     var ItemView = Backbone.View.extend({
         initialize: function(options) {
+            this.options = options;
             this.trackingUserPosition = this.options.trackingUserPosition;
             this.showInfo = this.options.showInfo;
             this.model.on('change:highlighted', _.bind(this.highlight, this));

--- a/app/libs/moxiejs/app/places/views/SearchView.js
+++ b/app/libs/moxiejs/app/places/views/SearchView.js
@@ -35,6 +35,20 @@ define(['jquery', 'backbone', 'underscore', 'moxie.conf', 'places/views/ItemView
             'click .map-options .sort-nearby': "sortNearby",
             'click .map-options .sort-az': "sortAZ",
             'click .map-options .filter a': "filter",
+
+            'click a.result-link': "clickResult",
+        },
+
+        clickResult: function(ev) {
+            if ($('.map-browse-layout.with-detail').length===1) {
+                // Silent browse, replace URL but don't write in history
+                ev.preventDefault();
+                Backbone.history.navigate(Backbone.history.reverse('detail', {id: ev.target.id} ), {trigger: true, replace: true});
+                return false;
+            } else {
+                // Normal browse, write to history
+                return true;
+            }
         },
 
         filtering: false,


### PR DESCRIPTION
While the detail view is open the search view will not record a "normal"
page browse ie. no change written to the browser history.
