### PR TITLE
Always show the thing one is looking at as a primary marker

### DIFF
--- a/app/libs/moxiejs/app/places/collections/NumberedPOICollection.js
+++ b/app/libs/moxiejs/app/places/collections/NumberedPOICollection.js
@@ -18,7 +18,7 @@ define(['underscore', 'places/collections/POICollection', 'places/models/Numbere
                 //
                 // Numbering maps a {lat+lon} string to an Array of pois
                 var numbering = {};
-                var count = 1;
+                var count = 0;
                 _.each(pois, function(poi) {
                     var latlon = "" + poi.lat + poi.lon;
                     if (latlon in numbering) {
@@ -29,6 +29,7 @@ define(['underscore', 'places/collections/POICollection', 'places/models/Numbere
                         numbering[latlon] = [poi];
                         count++;
                     }
+                    poi.markerText = (poi.number === 0) ? '<i class="fa fa-sign-in"></i>' : poi.number;
                 });
                 this.numberOfMarkers = _.size(numbering);
             }

--- a/app/libs/moxiejs/app/places/models/NumberedPOIModel.js
+++ b/app/libs/moxiejs/app/places/models/NumberedPOIModel.js
@@ -12,12 +12,12 @@ define(['leaflet', 'places/models/POIModel'], function(L, POI) {
             if (this.has('lat') && this.has('lon')) {
                 var latlng = new L.LatLng(this.get('lat'), this.get('lon'));
                 var icon = L.divIcon({
-                    html: '<div><span>' + this.get('number') + '</span></div>', iconSize: new L.Point(30, 30),
+                    html: '<div><span>' + this.get('markerText') + '</span></div>', iconSize: new L.Point(30, 30),
                     className: 'numbered-marker',
                 });
                 return new L.marker(latlng, {icon: icon, title: this.get('name')});
             }
-        },
+        }
     });
     return NumberedPOI;
 });

--- a/app/libs/moxiejs/app/places/templates/detail.handlebars
+++ b/app/libs/moxiejs/app/places/templates/detail.handlebars
@@ -135,7 +135,7 @@
             {{#if href}}
             <dd><a href="#{{ href }}" title="{{ title }}">{{ title }}</a></dd>
             {{else}}
-            <dd>{{#if number}}<div class="detail-numbered-marker"><div><span>{{ number }}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
+            <dd>{{#if markerText }}<div class="detail-numbered-marker"><div><span>{{{ markerText }}}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
             {{/if}}
             {{/occupiedBy}}
         {{/if}}
@@ -145,7 +145,7 @@
             {{#if href}}
             <dd><a href="#{{ href }}" title="{{ title }}">{{ title }}</a></dd>
             {{else}}
-            <dd>{{#if number}}<div class="detail-numbered-marker"><div><span>{{ number }}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
+            <dd>{{#if markerText }}<div class="detail-numbered-marker"><div><span>{{{ markerText }}}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
             {{/if}}
             {{/partOf}}
         {{/if}}
@@ -155,7 +155,7 @@
             {{#if href}}
             <dd><a href="#{{ href }}" title="{{ title }}">{{ title }}</a></dd>
             {{else}}
-            <dd>{{#if number}}<div class="detail-numbered-marker"><div><span>{{ number }}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
+            <dd>{{#if markerText }}<div class="detail-numbered-marker"><div><span>{{{ markerText }}}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
             {{/if}}
             {{/occupies}}
         {{/if}}
@@ -163,9 +163,9 @@
             <dt>Libraries</dt>
             {{#libraries}}
             {{#if href}}
-            <dd><a href="#{{ href }}" title="{{ title }}">{{ title }}</a></dd>
+            <dd><a href="#{{ href }}" title="{{ title }}">a {{ title }}</a></dd>
             {{else}}
-            <dd>{{#if number}}<div class="detail-numbered-marker"><div><span>{{ number }}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
+            <dd>{{#if markerText }}<div class="detail-numbered-marker"><div><span>{{{ markerText }}}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
             {{/if}}
             {{/libraries}}
         {{/if}}
@@ -173,9 +173,9 @@
             <dt>Contains</dt>
             {{#contains}}
             {{#if href}}
-            <dd><a href="#{{ href }}" title="{{ title }}">{{ title }}</a></dd>
+            <dd><a href="#{{ href }}" title="{{ title }}">a {{ title }}</a></dd>
             {{else}}
-            <dd>{{#if number}}<div class="detail-numbered-marker"><div><span>{{ number }}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
+            <dd>{{#if markerText }}<div class="detail-numbered-marker"><div><span>{{{ markerText }}}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
             {{/if}}
             {{/contains}}
         {{/if}}
@@ -185,7 +185,7 @@
             {{#if href}}
             <dd><a href="#{{ href }}" title="{{ title }}">{{ title }}</a></dd>
             {{else}}
-            <dd>{{#if number}}<div class="detail-numbered-marker"><div><span>{{ number }}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
+            <dd>{{#if markerText }}<div class="detail-numbered-marker"><div><span>{{{ markerText }}}</span></div></div>{{/if}}<a href="{{ reverse 'detail' 'id' id }}" title="{{ name }}">{{ name }}</a></dd>
             {{/if}}
             {{/organisations}}
         {{/if}}

--- a/app/libs/moxiejs/app/places/views/DetailView.js
+++ b/app/libs/moxiejs/app/places/views/DetailView.js
@@ -208,11 +208,12 @@ define(['jquery', 'backbone', 'underscore', 'moxie.conf', 'core/views/ErrorView'
             if (!this.additionalPOIs) {
                 if (this.model.has('_links')) {
                     var primaryPlaceId;
+                    var poids = [];
                     if(this.model.get('_links').primary_place && this.model.get('_links').primary_place.href) {
                         primaryPlaceId = this.model.get('_links').primary_place.href;
                     }
+                    poids.push(this.model.get('_links').self.href.split('/').pop());
                     var children = this.model.get('_links').child || [];
-                    var poids = [];
                     _.each(children, function(child) {
                         if (this.inclusionPredicate(child)) {
                             poids.push(child.href.split('/').pop());


### PR DESCRIPTION
This adds the current object as the first `poid` in the detail view, and starts counting them from `0`, not `1`. The `0` marker is then replaced with a font-awesome `sign-in` icon to signify that that's the way in.

This will mean that the thing we're looking at is always the most obvious marker on the map.

Closes #75.